### PR TITLE
19-replace-spring-fox-with-springdoc-openapi

### DIFF
--- a/store-base/store-build-chassis/pom.xml
+++ b/store-base/store-build-chassis/pom.xml
@@ -42,13 +42,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Start - API documentation with Swagger -->
-            <dependency>
-                <groupId>io.springfox</groupId>
-                <artifactId>springfox-swagger2</artifactId>
-                <version>${springfox.swagger.version}</version>
-            </dependency>
-            <!-- End - API documentation with Swagger -->
+            <!-- Removed springfox-swagger2 dependency management. Springdoc OpenAPI is managed per module. -->
             <!-- Start - Spring cloud dependencies -->
             <dependency>
                 <groupId>org.springframework.cloud</groupId>

--- a/store-common/store-api/pom.xml
+++ b/store-common/store-api/pom.xml
@@ -37,8 +37,10 @@
     <dependencies>
         <!-- Start - API documentation dependencies -->
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-webflux-ui</artifactId>
+            <version>1.8.0</version>
         </dependency>
+        <!-- End - API documentation dependencies -->
     </dependencies>
 </project>

--- a/store-common/store-api/src/main/java/com/siriusxi/ms/store/api/composite/StoreEndpoint.java
+++ b/store-common/store-api/src/main/java/com/siriusxi/ms/store/api/composite/StoreEndpoint.java
@@ -1,10 +1,10 @@
 package com.siriusxi.ms.store.api.composite;
 
 import com.siriusxi.ms.store.api.composite.dto.ProductAggregate;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
@@ -20,7 +20,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
  * @version v5.8
  * @since v3.0 codename Storm
  */
-@Api("REST API for Springy Store products information.")
+@Tag(name = "Store", description = "REST API for Springy Store products information.")
 @RequestMapping("store/api/v1")
 public interface StoreEndpoint extends StoreService {
 
@@ -33,25 +33,14 @@ public interface StoreEndpoint extends StoreService {
    * @return the composite product info, if found, else null.
    * @since v3.0 codename Storm.
    */
-  @ApiOperation(
-      value = "${api.product-composite.get-composite-product.description}",
-      notes = "${api.product-composite.get-composite-product.notes}")
-  @ApiResponses(
-      value = {
-        @ApiResponse(
-            code = 400,
-            message = """
-                    Bad Request, invalid format of the request.
-                    See response message for more information.
-                    """),
-        @ApiResponse(code = 404, message = "Not found, the specified id does not exist."),
-        @ApiResponse(
-            code = 422,
-            message = """
-                    Unprocessable entity, input parameters caused the processing to fails.
-                    See response message for more information.
-                    """)
-      })
+  @Operation(
+      summary = "${api.product-composite.get-composite-product.description}",
+      description = "${api.product-composite.get-composite-product.notes}")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "400", description = "Bad Request, invalid format of the request. See response message for more information."),
+    @ApiResponse(responseCode = "404", description = "Not found, the specified id does not exist."),
+    @ApiResponse(responseCode = "422", description = "Unprocessable entity, input parameters caused the processing to fails. See response message for more information.")
+  })
   @GetMapping(value = "products/{id}",
           produces = APPLICATION_JSON_VALUE)
   @Override
@@ -70,24 +59,13 @@ public interface StoreEndpoint extends StoreService {
    * @since v3.0 codename Storm.
    * @return Nothing.
    */
-  @ApiOperation(
-      value = "${api.product-composite.create-composite-product.description}",
-      notes = "${api.product-composite.create-composite-product.notes}")
-  @ApiResponses(
-      value = {
-        @ApiResponse(
-            code = 400,
-            message = """
-                Bad Request, invalid format of the request. 
-                See response message for more information.
-                """),
-        @ApiResponse(
-            code = 422,
-            message = """
-                Unprocessable entity, input parameters caused the processing to fail. 
-                See response message for more information.
-                """)
-      })
+  @Operation(
+      summary = "${api.product-composite.create-composite-product.description}",
+      description = "${api.product-composite.create-composite-product.notes}")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "400", description = "Bad Request, invalid format of the request. See response message for more information."),
+    @ApiResponse(responseCode = "422", description = "Unprocessable entity, input parameters caused the processing to fail. See response message for more information.")
+  })
   @PostMapping(
           value = "products",
           consumes = APPLICATION_JSON_VALUE)
@@ -103,25 +81,14 @@ public interface StoreEndpoint extends StoreService {
    * @since v3.0 codename Storm.
    * @return Nothing.
    */
-  @ApiOperation(
-      value = "${api.product-composite.delete-composite-product.description}",
-      notes = "${api.product-composite.delete-composite-product.notes}")
-  @ApiResponses(
-      value = {
-        @ApiResponse(
-            code = 400,
-            message ="""
-                Bad Request, invalid format of the request. 
-                See response message for more information.
-                """),
-        @ApiResponse(
-            code = 422,
-            message ="""
-                Unprocessable entity, input parameters caused the processing to fail. 
-                See response message for more information.
-                """)
-      })
-  @DeleteMapping("products/{id}")
+  @Operation(
+      summary = "${api.product-composite.delete-composite-product.description}",
+      description = "${api.product-composite.delete-composite-product.notes}")
+  @ApiResponses(value = {
+    @ApiResponse(responseCode = "400", description = "Bad Request, invalid format of the request. See response message for more information."),
+    @ApiResponse(responseCode = "422", description = "Unprocessable entity, input parameters caused the processing to fail. See response message for more information.")
+  })
+  @DeleteMapping(value = "products/{id}")
   @Override
   Mono<Void> deleteProduct(@PathVariable int id);
 }

--- a/store-services/store-service/pom.xml
+++ b/store-services/store-service/pom.xml
@@ -24,18 +24,9 @@
     <dependencies>
         <!-- Start - API documentation dependencies -->
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-spring-webflux</artifactId>
-            <version>${springfox.swagger.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger-ui</artifactId>
-            <version>${springfox.swagger.version}</version>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-webflux-ui</artifactId>
+            <version>1.8.0</version>
         </dependency>
         <!-- End - API documentation dependencies -->
         <!-- Start - Security dependency -->

--- a/store-services/store-service/src/main/java/com/siriusxi/ms/store/pcs/StoreServiceApplication.java
+++ b/store-services/store-service/src/main/java/com/siriusxi/ms/store/pcs/StoreServiceApplication.java
@@ -3,10 +3,8 @@ package com.siriusxi.ms.store.pcs;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
-import springfox.documentation.swagger2.annotations.EnableSwagger2WebFlux;
 
 @SpringBootApplication
-@EnableSwagger2WebFlux // Starting point for initiating SpringFox
 @ComponentScan("com.siriusxi.ms.store")
 public class StoreServiceApplication {
   public static void main(String[] args) {

--- a/store-services/store-service/src/main/java/com/siriusxi/ms/store/pcs/config/StoreServiceConfiguration.java
+++ b/store-services/store-service/src/main/java/com/siriusxi/ms/store/pcs/config/StoreServiceConfiguration.java
@@ -5,15 +5,6 @@ import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spring.web.plugins.Docket;
-
-import static java.util.Collections.emptyList;
-import static org.springframework.web.bind.annotation.RequestMethod.*;
-import static springfox.documentation.builders.RequestHandlerSelectors.basePackage;
-import static springfox.documentation.spi.DocumentationType.SWAGGER_2;
 
 @Configuration
 public class StoreServiceConfiguration {
@@ -44,48 +35,6 @@ public class StoreServiceConfiguration {
 
   @Value("${api.common.contact.email}")
   private String apiContactEmail;
-
-  /**
-   * Will exposed on $HOST:$PORT/swagger-ui.html
-   *
-   * @return Docket swagger configuration
-   */
-  @Bean
-  public Docket apiDocumentation() {
-
-    return new Docket(SWAGGER_2)
-        .select()
-        /*
-           Using the apis() and paths() methods,
-           we can specify where SpringFox shall look for API documentation.
-        */
-        .apis(basePackage("com.siriusxi.ms.store"))
-        .paths(PathSelectors.any())
-        .build()
-        /*
-            Using the globalResponseMessage() method, we ask SpringFox not to add any default HTTP
-            response codes to the API documentation, such as 401 and 403,
-            which we don't currently use.
-        */
-        .globalResponseMessage(POST, emptyList())
-        .globalResponseMessage(GET, emptyList())
-        .globalResponseMessage(DELETE, emptyList())
-        /*
-            The api* variables that are used to configure the Docket bean with general
-            information about the API are initialized from the property file using
-            Spring @Value annotations.
-        */
-        .apiInfo(
-            new ApiInfo(
-                apiTitle,
-                apiDescription,
-                apiVersion,
-                apiTermsOfServiceUrl,
-                new Contact(apiContactName, apiContactUrl, apiContactEmail),
-                apiLicense,
-                apiLicenseUrl,
-                emptyList()));
-  }
 
   @Bean
   @LoadBalanced


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Upgraded API documentation to use OpenAPI 3.x annotations and SpringDoc OpenAPI UI for improved compatibility and modern standards.

- **Refactor**
	- Replaced all Swagger 2.x (Springfox) annotations and dependencies with OpenAPI 3.x equivalents across relevant modules.
	- Removed legacy Swagger configuration and related code.

- **Chores**
	- Updated project dependencies and cleaned up obsolete API documentation setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->